### PR TITLE
Support `owner/dprint-plugin-{name}` pattern with hardcoded list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,9 @@ dprint 0.40.0
 It is intentionally keeping in main branch and not to be updated.\
 Because of version 1.1.0 actually did not point to tagged version.
 I will remove it after few months.
+
+## How to write the regex?
+
+Basically you can check in [regex101.com](https://regex101.com/r/162Ui3/1).
+
+Keep in mind that renovatebot has [RE2](https://github.com/google/re2/wiki/Syntax) limitations.

--- a/default.json
+++ b/default.json
@@ -14,18 +14,18 @@
       "customType": "regex",
       "fileMatch": ["dprint.json", "dprint.jsonc", ".dprint.json", ".dprint.jsonc"],
       "matchStrings": [
-        "\"https://plugins.dprint.dev/(?<owner>[^/-]+)/(?<pluginName>kdl)-(?<currentValue>[^/-]+?).wasm\""
+        "\"https://plugins.dprint.dev/(?<user>g-plane)/(?<pluginName>[^/-]+)-(?<currentValue>[^/]+?).wasm\""
       ],
-      "depNameTemplate": "{{{owner}}}/dprint-plugin-{{{pluginName}}}",
+      "depNameTemplate": "{{{user}}}/{{{pluginName}}}",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
       "fileMatch": ["dprint.json", "dprint.jsonc", ".dprint.json", ".dprint.jsonc"],
       "matchStrings": [
-        "\"https://plugins.dprint.dev/(?<depName>[^/]+/[^/]+)-(?<currentValue>[^/]+?).wasm\""
+        "\"https://plugins.dprint.dev/(?<user>kachick)/(?<pluginName>[^/-]+)-(?<currentValue>[^/-]+?).wasm\""
       ],
-      "depNameTemplate": "{{{depName}}}",
+      "depNameTemplate": "{{{user}}}/dprint-plugin-{{{pluginName}}}",
       "datasourceTemplate": "github-releases"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -5,9 +5,18 @@
       "customType": "regex",
       "fileMatch": ["dprint.json", "dprint.jsonc", ".dprint.json", ".dprint.jsonc"],
       "matchStrings": [
-        "\"https://plugins.dprint.dev/(?<depName>[^/]+)-(?<currentValue>[^/]+?).wasm\""
+        "\"https://plugins.dprint.dev/(?<pluginName>[^/-]+)-(?<currentValue>[^/-]+?).wasm\""
       ],
-      "depNameTemplate": "dprint/dprint-plugin-{{{depName}}}",
+      "depNameTemplate": "dprint/dprint-plugin-{{{pluginName}}}",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["dprint.json", "dprint.jsonc", ".dprint.json", ".dprint.jsonc"],
+      "matchStrings": [
+        "\"https://plugins.dprint.dev/(?<owner>[^/-]+)/(?<pluginName>kdl)-(?<currentValue>[^/-]+?).wasm\""
+      ],
+      "depNameTemplate": "{{{owner}}}/dprint-plugin-{{{pluginName}}}",
       "datasourceTemplate": "github-releases"
     },
     {

--- a/dprint.json
+++ b/dprint.json
@@ -18,6 +18,10 @@
   },
   "markup": {
   },
+  "graphql": {
+  },
+  "kdl": {
+  },
   "excludes": [
     "**/node_modules",
     "**/*-lock.json",
@@ -33,6 +37,7 @@
     "https://plugins.dprint.dev/g-plane/malva-v0.10.1.wasm",
     "https://plugins.dprint.dev/g-plane/markup_fmt-v0.12.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.1.0.wasm",
     "https://plugins.dprint.dev/kachick/kdl-0.1.0.wasm"
   ]
 }


### PR DESCRIPTION
- **Attempt to fix dprint-plugin- pattern**
- **Prefer list based solution to cover plugins**
- **Add pretty_graphql in test targets**

Resolves GH-239
